### PR TITLE
Code cleanup

### DIFF
--- a/evaluation/chatbot/evaluate.py
+++ b/evaluation/chatbot/evaluate.py
@@ -20,7 +20,7 @@ from evaluation.chatbot.evaluators.function_call_reliability import (
 )
 from evaluation.chatbot.eval_target import SupportTicketEvaluationTarget
 from evaluation.evaluation_service import EvaluationService
-from evaluation import common as utils
+from evaluation.common import copy_and_execute_notebook, generate_experiment_name
 
 # Set the logging level for semantic_kernel.kernel to DEBUG.
 setup_logging()
@@ -56,7 +56,7 @@ def run_support_ticket_evaluation(
         ground_truth_data_path
         or f"{chatbot_eval_root_path()}/ground-truth/support_ticket_eval_dataset.json"
     )
-    experiment_name = experiment_name or utils.generate_experiment_name(
+    experiment_name = experiment_name or generate_experiment_name(
         name="Support_Ticket_Chatbot_Eval"
     )
     output_path = f"{chatbot_eval_root_path()}/output/{experiment_name}"
@@ -92,28 +92,12 @@ def run_support_ticket_evaluation(
         experiment_name=experiment_name,
     )
 
-    # Copy error analysis notebook into output directory
-    import shutil
-    notebook_src = os.path.join(chatbot_eval_root_path(), "error_analysis_chatbot.ipynb")
-    notebook_dst = os.path.join(output_path, "error_analysis_chatbot.ipynb")
-    try:
-        shutil.copy(notebook_src, notebook_dst)
-        print(f"Copied error analysis notebook to {notebook_dst}")
-        # Execute all cells in the notebook after copying
-        import nbformat
-        from nbconvert.preprocessors import ExecutePreprocessor
-        with open(notebook_dst, "r", encoding="utf-8") as f:
-            nb = nbformat.read(f, as_version=4)
-        ep = ExecutePreprocessor(kernel_name="python3")
-        try:
-            ep.preprocess(nb, {"metadata": {"path": os.path.dirname(notebook_dst)}})
-            with open(notebook_dst, "w", encoding="utf-8") as f:
-                nbformat.write(nb, f)
-            print(f"Executed and saved notebook with outputs: {notebook_dst}")
-        except Exception as e:
-            print(f"Warning: Failed to execute notebook: {e}")
-    except Exception as e:
-        print(f"Warning: Could not copy error analysis notebook: {e}")
+    # Copy and execute error analysis notebook
+    copy_and_execute_notebook(
+        notebook_name="error_analysis_chatbot.ipynb",
+        root_path=str(chatbot_eval_root_path()),
+        output_path=output_path
+    )
 
     # convert results to dataframe
     df = pd.DataFrame(results).round(2)

--- a/evaluation/chatbot/evaluate.py
+++ b/evaluation/chatbot/evaluate.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 import pandas as pd
 import logging
 import os
@@ -95,8 +96,8 @@ def run_support_ticket_evaluation(
     # Copy and execute error analysis notebook
     copy_and_execute_notebook(
         notebook_name="error_analysis_chatbot.ipynb",
-        root_path=str(chatbot_eval_root_path()),
-        output_path=output_path
+        root_path=chatbot_eval_root_path(),
+        output_path=Path(output_path)
     )
 
     # convert results to dataframe

--- a/evaluation/common.py
+++ b/evaluation/common.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 import json
+import logging
 import os
-from pathlib import Path
+import shutil
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
 
 
 def convert_json_to_jsonl(filePath: str) -> str:
@@ -60,3 +63,35 @@ def generate_experiment_name(name: str = "Eval") -> str:
     """
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
     return f"{name}_{timestamp}"
+
+
+def copy_and_execute_notebook(notebook_name: str, root_path: str, output_path: str) -> None:
+    """
+    Copy and execute a notebook to the output directory
+
+    Args:
+        notebook_name (str): Name of the notebook file
+        root_path (str): Root path where the notebook is located
+        output_path (str): Path to the output directory where the notebook will be copied
+    """
+    notebook_src = os.path.join(root_path, notebook_name)
+    notebook_dst = os.path.join(output_path, notebook_name)
+    
+    try:
+        shutil.copy(notebook_src, notebook_dst)
+        logging.info(f"Copied notebook from {notebook_src} to {notebook_dst}")
+        
+        # Execute all cells in the notebook after copying
+        with open(notebook_dst, "r", encoding="utf-8") as f:
+            nb = nbformat.read(f, as_version=4)
+            
+        ep = ExecutePreprocessor(kernel_name="python3")
+        try:
+            ep.preprocess(nb, {"metadata": {"path": os.path.dirname(notebook_dst)}})
+            with open(notebook_dst, "w", encoding="utf-8") as f:
+                nbformat.write(nb, f)
+            logging.info(f"Executed and saved notebook with outputs: {notebook_dst}")
+        except Exception as e:
+            logging.warning(f"Failed to execute notebook: {e}")
+    except Exception as e:
+        logging.warning(f"Could not copy notebook: {e}")

--- a/evaluation/common.py
+++ b/evaluation/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import json
-import logging
 import os
+from pathlib import Path
 import shutil
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
@@ -65,21 +65,21 @@ def generate_experiment_name(name: str = "Eval") -> str:
     return f"{name}_{timestamp}"
 
 
-def copy_and_execute_notebook(notebook_name: str, root_path: str, output_path: str) -> None:
+def copy_and_execute_notebook(notebook_name: str, root_path: Path, output_path: Path) -> None:
     """
     Copy and execute a notebook to the output directory
 
     Args:
         notebook_name (str): Name of the notebook file
-        root_path (str): Root path where the notebook is located
-        output_path (str): Path to the output directory where the notebook will be copied
+        root_path (Path): Root path where the notebook is located
+        output_path (Path): Path to the output directory where the notebook will be copied
     """
     notebook_src = os.path.join(root_path, notebook_name)
     notebook_dst = os.path.join(output_path, notebook_name)
     
     try:
+        print(f"Copying notebook from {notebook_src} to {notebook_dst}")
         shutil.copy(notebook_src, notebook_dst)
-        logging.info(f"Copied notebook from {notebook_src} to {notebook_dst}")
         
         # Execute all cells in the notebook after copying
         with open(notebook_dst, "r", encoding="utf-8") as f:
@@ -87,11 +87,12 @@ def copy_and_execute_notebook(notebook_name: str, root_path: str, output_path: s
             
         ep = ExecutePreprocessor(kernel_name="python3")
         try:
+            print(f"Executing notebook: {notebook_dst}")
             ep.preprocess(nb, {"metadata": {"path": os.path.dirname(notebook_dst)}})
             with open(notebook_dst, "w", encoding="utf-8") as f:
                 nbformat.write(nb, f)
-            logging.info(f"Executed and saved notebook with outputs: {notebook_dst}")
+            print(f"Executed and saved notebook with outputs: {notebook_dst}")
         except Exception as e:
-            logging.warning(f"Failed to execute notebook: {e}")
+            print(f"Failed to execute notebook: {e}")
     except Exception as e:
-        logging.warning(f"Could not copy notebook: {e}")
+        print(f"Could not copy notebook: {e}")

--- a/evaluation/common.py
+++ b/evaluation/common.py
@@ -74,8 +74,8 @@ def copy_and_execute_notebook(notebook_name: str, root_path: Path, output_path: 
         root_path (Path): Root path where the notebook is located
         output_path (Path): Path to the output directory where the notebook will be copied
     """
-    notebook_src = os.path.join(root_path, notebook_name)
-    notebook_dst = os.path.join(output_path, notebook_name)
+    notebook_src = root_path / notebook_name
+    notebook_dst = output_path / notebook_name
     
     try:
         print(f"Copying notebook from {notebook_src} to {notebook_dst}")


### PR DESCRIPTION
This pull request refactors the `evaluation/chatbot/evaluate.py` script to improve modularity and reusability by moving common functionality to `evaluation/common.py`. The most important changes include replacing inline logic for copying and executing notebooks with a reusable function, updating imports accordingly, and simplifying experiment name generation.

### Refactoring and Modularity Improvements:
* Moved the logic for copying and executing notebooks into a new reusable function `copy_and_execute_notebook` in `evaluation/common.py`. This function handles copying a notebook to the output directory and executing its cells, improving code reuse.
* Replaced the inline notebook copying and execution logic in `evaluation/chatbot/evaluate.py` with a call to the new `copy_and_execute_notebook` function.