### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-workflow ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Lint
+      uses: devcontainers/ci@v0.3
+      with:
+        runCmd: make lint
+        
+    - name: Test
+      uses: devcontainers/ci@v0.3
+      with:
+        runCmd: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Lint
-      uses: devcontainers/ci@v0.3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
       with:
-        runCmd: make lint
+        python-version: '3.11'
         
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install uv
+        make install
+        
+    - name: Lint
+      run: make lint
+      
     - name: Test
-      uses: devcontainers/ci@v0.3
-      with:
-        runCmd: make test
+      run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, ci-workflow ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/evaluation/chatbot/simulation/chat_simulator.py
+++ b/evaluation/chatbot/simulation/chat_simulator.py
@@ -86,10 +86,9 @@ class SupportTicketChatSimulator:
             # Convert to list of messages to satisfy the type checker
             messages_list = await agent_thread.get_messages()
             # # Convert ChatHistory to list[ChatMessageContent] to solve type compatibility issue
-            # message_content_list = [msg for msg in messages_list]
             should_agent_terminate = await termination_strategy.should_agent_terminate(
                 agent=support_ticket_agent,
-                history=messages_list,
+                history=[msg for msg in messages_list],
             )
 
             if should_agent_terminate:

--- a/evaluation/chatbot/simulation/chat_simulator.py
+++ b/evaluation/chatbot/simulation/chat_simulator.py
@@ -88,7 +88,7 @@ class SupportTicketChatSimulator:
             # # Convert ChatHistory to list[ChatMessageContent] to solve type compatibility issue
             should_agent_terminate = await termination_strategy.should_agent_terminate(
                 agent=support_ticket_agent,
-                history=[msg for msg in messages_list],
+                history=[msg for msg in messages_list], # list comprehension required for resolving type compatibility
             )
 
             if should_agent_terminate:

--- a/evaluation/chatbot/test/evaluators/test_function_call_reliability.py
+++ b/evaluation/chatbot/test/evaluators/test_function_call_reliability.py
@@ -6,6 +6,8 @@ from evaluation.chatbot.test.evaluators.test_data import (
     FC_TICKET_CREATE,
     FC_TICKET_CREATE_2,
     FC_TICKET_CREATE_2_DIFF_ARGS,
+    FC_TICKET_CREATE_DIFF_ARGS,
+    FC_TICKET_CREATE_DIFF_NAME,
 )
 
 
@@ -24,15 +26,15 @@ def __call_evaluator(actual: list[dict], expected: list[dict], expected_score: f
             1.0,  # perfect precision and recall
         ),
         (
-            [FC_TICKET_CREATE, FC_TICKET_CREATE_2],
             [FC_TICKET_CREATE],
-            0.0,  # precision not 1
+            [FC_TICKET_CREATE_DIFF_ARGS],
+            0.5,  # argument recall not 1
         ),
         (
-            [FC_TICKET_CREATE],
             [FC_TICKET_CREATE, FC_TICKET_CREATE_2],
-            0.0,  # recall not 1
-        ),
+            [FC_TICKET_CREATE_DIFF_NAME, FC_TICKET_CREATE_2_DIFF_ARGS],
+            0.25,  # argument recall of second function call is not 1
+        )
     ],
 )
 def test_function_call_reliability(actual, expected, expected_score):


### PR DESCRIPTION
This pull request introduces a new CI workflow for linting and testing the Python code. Required type and test fixes are included.

Sample CI run: https://github.com/marcgs/lob-chatbot-sample/actions/runs/15157671745

### CI Workflow Setup:
* Added a new GitHub Actions workflow `.github/workflows/ci.yml` to automate CI tasks. The workflow runs on `ubuntu-latest`, sets up Python 3.11, installs dependencies, and performs linting and testing.

### Chatbot Simulation Improvements:
* Updated `run` method in `chat_simulator.py` to resolve a type compatibility issue by converting `messages_list` into a list comprehension when passing it to the `termination_strategy.should_agent_terminate` method.

### Test Updates for Function Call Reliability:
* Added new test cases in `test_function_call_reliability.py` to cover scenarios with differing arguments and names (`FC_TICKET_CREATE_DIFF_ARGS`, `FC_TICKET_CREATE_DIFF_NAME`). [[1]](diffhunk://#diff-9661c6f74a87e056a6526f4d5a2ad84be7cbf0a34813f7463e5c2b429bd00ce5R9-R10) [[2]](diffhunk://#diff-9661c6f74a87e056a6526f4d5a2ad84be7cbf0a34813f7463e5c2b429bd00ce5L27-R37)